### PR TITLE
Add KikuchiPy to list of HyperSpy extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ HyperSpy extensions are packages that use the hyperspy extension mechanism to ad
 
 The following is a non-exhaustive list of HyperSpy extensions. If you would like to add your package here, just send us a pull request.
 
-| Package name                                                                   | Brief description               |
-|--------------------------------------------------------------------------------|---------------------------------|
-| [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy |
-| [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy   |
+| Package name                                                                   | Brief description                                                    |
+|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                      |
+| [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                        |
+| [KikuchiPy](https://github.com/kikuchipy/kikuchipy)                            | Processing and analysis of electron backscatter diffraction patterns |


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

So I've created an `EBSD` class which extends `Signal2D`, with so far some basic pattern processing. The package, named KikuchiPy (https://github.com/kikuchipy/kikuchipy), also has three readers for EBSD formats (NORDIF binary and h5ebsd Bruker/EDAX), with more to come. Anyway, I would be very happy if I could put it on this list.

If there is any other action related to the package that any of you HyperSpy maintainers would like me to perform, I will be happy to discuss it.

Lastly, thank you all for the powerful framework and set of tools that is HyperSpy :raised_hands: 