### PR TITLE
Fix permissions update readme workflow

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   update_readme:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and send us a pull request.
 | [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                           |
 | [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                             |
 
-## List of `signal_type`'s provided by the different HyperSpy extensions in alphabetical order
+## List of `signal_type` classes provided by the different HyperSpy extensions in alphabetical order
 
 
 <table>


### PR DESCRIPTION
Fix a permission issue in the update readme workflow, see https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/1161672777:

```
[main f639f52] Update README.md
 1 file changed, 1 insertion(+), 1 deletion(-)
remote: Permission to hyperspy/hyperspy-extensions-list.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/hyperspy/hyperspy-extensions-list/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

I have pushed [a branch](https://github.com/hyperspy/hyperspy-extensions-list/tree/fix_permission) to this repository to check that  it works.