### PR TITLE
Run kikuchipy tests with a virtual X server environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,10 +119,11 @@ jobs:
         run: |
           python -m pytest --pyargs hyperspy --reruns 3 -n 2 --instafail
 
-#      - name: Run Kikuchipy Test Suite
-#        if: ${{ always() }}
-#        run: |
-#          python -m pytest --pyargs kikuchipy
+      - name: Run kikuchipy Test Suite
+        if: ${{ always() }}
+        run: |
+          sudo apt-get install xvfb
+          xvfb-run python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and send us a pull request.
 |--------------------------------------------------------------------------------|----------------------------------------------------------------------|
 | [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                      |
 | [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                        |
-| [KikuchiPy](https://github.com/kikuchipy/kikuchipy)                            | Processing and analysis of electron backscatter diffraction patterns |
+| [kikuchipy](https://github.com/pyxem/kikuchipy)                                | Processing and analysis of electron backscatter diffraction patterns |
 | [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                           |
 | [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                             |
 


### PR DESCRIPTION
This PR enables running the kikuchipy test suite in a virtual X server environment (as is done in the kikuchipy repo). This is required for a couple of tests using PyVista.

PyVista was included as an optional dependency in kikuchipy v0.6. It is installed by default via conda, but is optional via `kikuchipy[viz]` from PyPI. Hence, the dev and pre-release CI runs downloading packages from PyPI won't have PyVista available and the mentioned tests won't run. We could support extension selectors by separating `EXTENSION` into `EXTENSION_CONDA` and `EXTENSION_PIP`, with the latter including selectors?