### PR TITLE
Fix install development version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,9 +106,11 @@ jobs:
       - name: Install Extension Dev
         if: contains(matrix.EXTENSION_VERSION, 'dev')
         run: |
-          pip install https://github.com/lumispy/lumispy/archive/main.zip --no-deps
-          pip install https://github.com/pyxem/kikuchipy/archive/main.zip --no-deps
-          pip install https://github.com/pyxem/pyxem/archive/master.zip --no-deps
+          # Needs to use --force-reinstall in case the development version is incorrect
+          # and pip doesn't update it
+          pip install https://github.com/lumispy/lumispy/archive/main.zip --no-deps --force-reinstall
+          pip install https://github.com/pyxem/kikuchipy/archive/main.zip --no-deps --force-reinstall
+          pip install https://github.com/pyxem/pyxem/archive/master.zip --no-deps --force-reinstall
 
       - name: Clear conda and pip cache
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,10 @@ jobs:
           conda clean --all
           pip cache purge
 
+      - name: Conda list
+        run: |
+          conda list
+
       - name: Run HyperSpy Test Suite
         run: |
           python -m pytest --pyargs hyperspy --reruns 3 -n 2 --instafail

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,4 +141,4 @@ jobs:
       - name: Run Pyxem Test Suite
         if: ${{ always() }}
         run: |
-          python -m pytest --pyargs pyxem -k "not test_correlations_wrapping"
+          python -m pytest --pyargs pyxem


### PR DESCRIPTION
Use `--force-reinstall` when installing with pip in case the development version is incorrect and pip doesn't install it because it thinks that it isn't necessary