### PR TITLE
Skip failing pyxem test (`test_correlations_wrapping`)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,4 +141,4 @@ jobs:
       - name: Run Pyxem Test Suite
         if: ${{ always() }}
         run: |
-          python -m pytest --pyargs pyxem
+          python -m pytest --pyargs pyxem -k "not test_correlations_wrapping"


### PR DESCRIPTION
Need to skip this test again as the numba update enable to use numpy 1.23 and this test fails with this version of numpy