### PR TITLE
Skip lazy random test for released version of hyperspy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,13 @@ jobs:
         run: |
           conda list
 
-      - name: Run HyperSpy Test Suite
+      - name: Run HyperSpy Test Suite (Release)
+        if: contains(matrix.HYPERSPY_VERSION, 'release')
+        run: |
+          python -m pytest --pyargs hyperspy --reruns 3 -n 2 --instafail -k "not test_random_state_lazy and not test_lazy_add_"
+
+      - name: Run HyperSpy Test Suite (Dev)
+        if: contains(matrix.HYPERSPY_VERSION, 'Rn')
         run: |
           python -m pytest --pyargs hyperspy --reruns 3 -n 2 --instafail
 


### PR DESCRIPTION
Skip test fixed in https://github.com/hyperspy/hyperspy/pull/3049.