### PR TITLE
Skip hyperspy tests failing with matplotlib 3.7 - 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,8 @@ jobs:
 
       - name: Run HyperSpy Test Suite
         run: |
-          python -m pytest --pyargs hyperspy
+          # Remove -k "..." when hyperspy > 1.7.3 is released
+          python -m pytest --pyargs hyperspy -k "not test_add_marker_signal2d_navigation_dim_vertical_line and not test_plot_images_multi_signal_w_axes_replot "
 
       - name: Run kikuchipy Test Suite
         if: ${{ always() }}


### PR DESCRIPTION
It is fixed in https://github.com/hyperspy/hyperspy/pull/3102 and only the test is broken.