### PR TITLE
Remove testing against scikit-image dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,12 +144,12 @@ jobs:
         run: |
           python -m pytest --pyargs hyperspy --reruns 3 -n 2
 
-      - name: Run kikuchipy Test Suite
-        if: ${{ always() }}
-        run: |
-          # Virtual buffer (xvfb) required for tests using PyVista
-          sudo apt-get install xvfb
-          xvfb-run python -m pytest --pyargs kikuchipy
+      # - name: Run kikuchipy Test Suite
+      #   if: ${{ always() }}
+      #   run: |
+      #     # Virtual buffer (xvfb) required for tests using PyVista
+      #     sudo apt-get install xvfb
+      #     xvfb-run python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,6 @@ jobs:
 
       - name: Run HyperSpy Test Suite
         run: |
-          # Remove -k "..." when hyperspy > 1.7.3 is released
           python -m pytest --pyargs hyperspy --reruns 3 -n 2
 
       - name: Run kikuchipy Test Suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: conda-incubator/setup-miniconda@master
+      - uses: conda-incubator/setup-miniconda@main
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -95,7 +95,8 @@ jobs:
           pip install --upgrade --pre --extra-index-url \
             https://pypi.anaconda.org/scipy-wheels-nightly/simple \
             ${{ matrix.DEPENDENCIES }}
-          pip install https://github.com/scikit-image/scikit-image/archive/main.zip
+          # Dev install broken with watershed (TypeError: No matching signature found)
+          # pip install https://github.com/scikit-image/scikit-image/archive/main.zip -v
 
       - name: Install dependencies pre release version
         if: ${{ matrix.DEPENDENCIES_PRE_RELEASE }}


### PR DESCRIPTION

- [x] Remove testing against scikit-image dev because it seems that there is an issue with the compilation of the scikit-image development version.
- [x] Disable kikuchipy test for now - see https://github.com/pyxem/kikuchipy/issues/634
