### PR TITLE
Reintroduce kikuchipy tests after segfault

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
             DEPENDENCIES: matplotlib numpy scipy sympy h5py scikit-image scikit-learn
             USE_MAMBA: false
           - DEPENDENCIES_NUMBA_DEV: true
-            # Instal dev version from numba/label/dev channel using mamba
+            # Install dev version from numba/label/dev channel using mamba
             LABEL: -dependencies_numba_dev
             HYPERSPY_VERSION: 'RnM'
             EXTENSION_VERSION: 'dev'
@@ -145,12 +145,12 @@ jobs:
         run: |
           python -m pytest --pyargs hyperspy --reruns 3 -n 2
 
-      # - name: Run kikuchipy Test Suite
-      #   if: ${{ always() }}
-      #   run: |
-      #     # Virtual buffer (xvfb) required for tests using PyVista
-      #     sudo apt-get install xvfb
-      #     xvfb-run python -m pytest --pyargs kikuchipy
+      - name: Run kikuchipy Test Suite
+        if: ${{ always() }}
+        run: |
+          # Virtual buffer (xvfb) required for tests using PyVista
+          sudo apt-get install xvfb
+          xvfb-run python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/readme_source/1-readme_base.md
+++ b/readme_source/1-readme_base.md
@@ -15,12 +15,12 @@ and send us a pull request.
 
 # (Known) HyperSpy extensions
 
-| Package name                                                                   | Brief description                                                    |
-|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                      |
-| [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                        |
-| [KikuchiPy](https://github.com/kikuchipy/kikuchipy)                            | Processing and analysis of electron backscatter diffraction patterns |
-| [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                           |
-| [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                             |
+| Package name                                                                   | Brief description                                                                |
+|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                                  |
+| [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                                    |
+| [kikuchipy](https://github.com/kikuchipy/kikuchipy)                            | Processing, simulating and indexing of electron backscatter diffraction patterns |
+| [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                                       |
+| [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                                         |
 
 ## List of `signal_type` classes provided by the different HyperSpy extensions in alphabetical order


### PR DESCRIPTION
Seems like the segmentation fault error previously experienced when running the kikuchipy tests, as reported in https://github.com/pyxem/kikuchipy/issues/634, are gone. I could not reproduce them locally, and neither could the GitHub actions in my fork of this repo (I've since disabled actions in my fork to reduce unnecessary computing).

I've also updated the kikuchipy description in the base README.