### PR TITLE
Update test build against development dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,8 @@ jobs:
 
       - name: Run HyperSpy Test Suite
         run: |
-          python -m pytest --pyargs hyperspy --reruns 3 -n 2
+          # https://github.com/hyperspy/hyperspy/pull/3124
+          python -m pytest --pyargs hyperspy --reruns 3 -n 2 -k "not test_variable_sigma"
 
       - name: Run kikuchipy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,14 +33,14 @@ jobs:
             LABEL: -dependencies_dev
             HYPERSPY_VERSION: 'RnM'
             EXTENSION_VERSION: 'dev'
-            DEPENDENCIES: numpy scipy scikit-learn
+            DEPENDENCIES: matplotlib scipy scikit-learn
             USE_MAMBA: false
           - DEPENDENCIES_PRE_RELEASE: true
             # Install RC version available on pypi
             LABEL: -dependencies_pre_release
             HYPERSPY_VERSION: 'RnM'
             EXTENSION_VERSION: 'dev'
-            DEPENDENCIES: matplotlib numpy scipy sympy h5py scikit-image scikit-learn
+            DEPENDENCIES: matplotlib scipy scikit-learn sympy h5py scikit-image
             USE_MAMBA: false
           - DEPENDENCIES_NUMBA_DEV: true
             # Install dev version from numba/label/dev channel using mamba


### PR DESCRIPTION
- Don't test numpy dev because it is not compatible with numba.
- Add test against matplotlib dev because it is now available on scipy-wheels-nightly.
- Skip test with scipy 1.11 - fixed in hyperspy