### PR TITLE
Don't install alpha release from mpmath in the dependency pre-release build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Install dependencies development version
         if: ${{ matrix.DEPENDENCIES_DEV }}
         run: |
+          # workaround for https://github.com/sympy/sympy/issues/26268
+          # remove when sympy supports mpmath 1.4
+          pip install mpmath
           pip install --upgrade --pre --extra-index-url \
           https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
           ${{ matrix.DEPENDENCIES }}
@@ -108,6 +111,9 @@ jobs:
       - name: Install dependencies pre release version
         if: ${{ matrix.DEPENDENCIES_PRE_RELEASE }}
         run: |
+          # workaround for https://github.com/sympy/sympy/issues/26268
+          # remove when sympy supports mpmath 1.4
+          pip install mpmath
           pip install --upgrade --pre ${{ matrix.DEPENDENCIES }}
 
       - name: Conda list


### PR DESCRIPTION
Workaround for https://github.com/sympy/sympy/issues/26268.