### PR TITLE
Add `filelock` test dependency required by rosettasccio

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       # EXTENSION: hyperspy-gui-ipywidgets hyperspy-gui-traitsui kikuchipy lumispy pyxem exspy holospy
       EXTENSION: hyperspy-gui-ipywidgets hyperspy-gui-traitsui lumispy pyxem exspy holospy
       # Unpin pytest, when pyxem 0.18 is release
-      TEST_DEPS: pytest==7.4.4 pytest-xdist pytest-rerunfailures pytest-mpl
+      TEST_DEPS: pytest==7.4.4 pytest-xdist pytest-rerunfailures pytest-mpl filelock
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Needed since https://github.com/hyperspy/rosettasciio/pull/245.

We can't enable running on several process because it needs to be released to work for the whole test matrix.