### PR TITLE
Re-enable kikuchipy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,9 +204,11 @@ jobs:
 
       - name: Run kikuchipy Test Suite
         if: ${{ always() }}
-        # run the tests headlessly
+        # Run the tests headlessly.
+        # Unskip test when https://github.com/pyxem/kikuchipy/issues/707 is fixed and
+        # released.
         run: |
-          xvfb-run python -m pytest --pyargs kikuchipy -k "not test_spherical_pyvista and not test_not_allow_download_raises"
+          xvfb-run python -m pytest --pyargs kikuchipy -k "not test_not_allow_download_raises"
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,7 @@ jobs:
             PYTHON_VERSION: '3.11'
 
     env:
-      # EXTENSION: hyperspy-gui-ipywidgets hyperspy-gui-traitsui kikuchipy lumispy pyxem exspy holospy
-      EXTENSION: hyperspy-gui-ipywidgets hyperspy-gui-traitsui lumispy pyxem exspy holospy
+      EXTENSION: hyperspy-gui-ipywidgets hyperspy-gui-traitsui kikuchipy lumispy pyxem exspy holospy
       TEST_DEPS: pytest pytest-xdist pytest-rerunfailures pytest-mpl filelock
     defaults:
       run:
@@ -143,7 +142,7 @@ jobs:
         if: contains(matrix.HYPERSPY_VERSION, 'RnMajor')
         run: |
           pip install "hyperspy[all] @ git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_major"
-  
+
       - name: Install Extension Release
         if: contains(matrix.EXTENSION_VERSION, 'release')
         run: |
@@ -155,8 +154,7 @@ jobs:
           pip install git+https://github.com/hyperspy/exspy.git
           pip install git+https://github.com/hyperspy/holospy.git
           pip install git+https://github.com/lumispy/lumispy.git
-          # uncomment when kikuchipy supports hyperspy 2
-          # pip install git+https://github.com/pyxem/kikuchipy.git
+          pip install git+https://github.com/pyxem/kikuchipy.git
           pip install git+https://github.com/pyxem/pyxem.git
           pip install git+https://github.com/hyperspy/hyperspy_gui_ipywidgets.git
           pip install git+https://github.com/hyperspy/hyperspy_gui_traitsui.git
@@ -184,7 +182,7 @@ jobs:
         if: ${{ always() }}
         run: |
           python -m pytest --pyargs hyperspy_gui_ipywidgets
-  
+
       - name: Run hyperspy_gui_traitsui Test Suite
         if: ${{ always() }}
         # run the tests headlessly
@@ -201,9 +199,9 @@ jobs:
         run: |
           python -m pytest --pyargs holospy
 
-      # - name: Run kikuchipy Test Suite
-      #   run: |
-      #     python -m pytest --pyargs kikuchipy
+      - name: Run kikuchipy Test Suite
+        run: |
+          python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Run kikuchipy Test Suite
         if: ${{ always() }}
         run: |
-          python -m pytest --pyargs kikuchipy
+          python -m pytest --pyargs kikuchipy -k "not test_spherical_pyvista and not test_not_allow_download_raises"
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,8 +204,9 @@ jobs:
 
       - name: Run kikuchipy Test Suite
         if: ${{ always() }}
+        # run the tests headlessly
         run: |
-          python -m pytest --pyargs kikuchipy -k "not test_spherical_pyvista and not test_not_allow_download_raises"
+          xvfb-run python -m pytest --pyargs kikuchipy -k "not test_spherical_pyvista and not test_not_allow_download_raises"
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,6 +203,7 @@ jobs:
           python -m pytest --pyargs holospy
 
       - name: Run kikuchipy Test Suite
+        if: ${{ always() }}
         run: |
           python -m pytest --pyargs kikuchipy
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and send us a pull request.
 | [holospy](https://github.com/hyperspy/holospy)                                 | Electron holography                                                                    |
 | [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                                        |
 | [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                                          |
-| [kikuchipy](https://github.com/kikuchipy/kikuchipy)                            | Processing, simulating and indexing of electron backscatter diffraction patterns       |
+| [kikuchipy](https://github.com/pyxem/kikuchipy)                                | Processing, simulating and indexing of electron backscatter diffraction patterns       |
 | [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                                             |
 | [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                                               |
 | [rosettasciio](https://github.com/hyperspy/rosettasciio)                       | Reading and writing of scientific data formats.                                        |
@@ -29,45 +29,49 @@ and send us a pull request.
 ## List of `signal_type` classes provided by the different HyperSpy extensions in alphabetical order
 
 
-|         signal_type         |                                  aliases                                  |          class name         | package |
-| :-------------------------: | :-----------------------------------------------------------------------: | :-------------------------: | :-----: |
-|          beam_shift         |                                                                           |          BeamShift          |  pyxem  |
-|            CL_SEM           |                       CLSEM, cathodoluminescence SEM                      |        CLSEMSpectrum        | lumispy |
-|           CL_STEM           |                      CLSTEM, cathodoluminescence STEM                     |        CLSTEMSpectrum       | lumispy |
-|              CL             |                      CLSpectrum, cathodoluminescence                      |          CLSpectrum         | lumispy |
-|         correlation         |                                                                           |        Correlation1D        |  pyxem  |
-|         correlation         |                                                                           |        Correlation2D        |  pyxem  |
-|             dpc             |                                                                           |         DPCSignal1D         |  pyxem  |
-|             dpc             |                                                                           |         DPCSignal2D         |  pyxem  |
-|      DielectricFunction     |                            dielectric function                            |      DielectricFunction     |  exspy  |
-|         diffraction         |                                                                           |        Diffraction1D        |  pyxem  |
-|         diffraction         |                                                                           |        Diffraction2D        |  pyxem  |
-|     diffraction_variance    |                                                                           |    DiffractionVariance1D    |  pyxem  |
-|     diffraction_variance    |                                                                           |    DiffractionVariance2D    |  pyxem  |
-|     diffraction_vectors     |                                                                           |      DiffractionVectors     |  pyxem  |
-|     diffraction_vectors     |                                                                           |     DiffractionVectors1D    |  pyxem  |
-|     diffraction_vectors     |                                                                           |     DiffractionVectors2D    |  pyxem  |
-|         tensor_field        |                                                                           |   DisplacementGradientMap   |  pyxem  |
-|           EDS_SEM           |                                                                           |        EDSSEMSpectrum       |  exspy  |
-|           EDS_TEM           |                                                                           |        EDSTEMSpectrum       |  exspy  |
-|             EELS            |                                  TEM EELS                                 |         EELSSpectrum        |  exspy  |
-|              EL             |                      ELSpectrum, electroluminescence                      |          ELSpectrum         | lumispy |
-|     electron_diffraction    |                                                                           |    ElectronDiffraction1D    |  pyxem  |
-|     electron_diffraction    |                                                                           |    ElectronDiffraction2D    |  pyxem  |
-|           hologram          |                                                                           |        HologramImage        | holospy |
-|      insitu_diffraction     |                                                                           |     InSituDiffraction2D     |  pyxem  |
-| labeled_diffraction_vectors |                                                                           | LabeledDiffractionVectors2D |  pyxem  |
-|         Luminescence        |                            LuminescenceSpectrum                           |         LumiSpectrum        | lumispy |
-|          Transient          |            TRLumi, TR luminescence, time-resolved luminescence            |        LumiTransient        | lumispy |
-|        TransientSpec        | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |    LumiTransientSpectrum    | lumispy |
-|       orientation_map       |                                                                           |        OrientationMap       |  pyxem  |
-|              PL             |                       PLSpectrum, photoluminescence                       |          PLSpectrum         | lumispy |
-|  pair_distribution_function |                                                                           |  PairDistributionFunction1D |  pyxem  |
-|      polar_diffraction      |                                                                           |      PolarDiffraction2D     |  pyxem  |
-|        polar_vectors        |                                                                           |         PolarVectors        |  pyxem  |
-|            power            |                                                                           |           Power2D           |  pyxem  |
-|      reduced_intensity      |                                                                           |      ReducedIntensity1D     |  pyxem  |
-|       vector_matching       |                                                                           |    VectorMatchingResults    |  pyxem  |
-|      virtual_dark_field     |                                                                           |    VirtualDarkFieldImage    |  pyxem  |
+|         signal_type         |                                  aliases                                  |          class name         |  package  |
+| :-------------------------: | :-----------------------------------------------------------------------: | :-------------------------: | :-------: |
+|          beam_shift         |                                                                           |          BeamShift          |   pyxem   |
+|            CL_SEM           |                       CLSEM, cathodoluminescence SEM                      |        CLSEMSpectrum        |  lumispy  |
+|           CL_STEM           |                      CLSTEM, cathodoluminescence STEM                     |        CLSTEMSpectrum       |  lumispy  |
+|              CL             |                      CLSpectrum, cathodoluminescence                      |          CLSpectrum         |  lumispy  |
+|         correlation         |                                                                           |        Correlation1D        |   pyxem   |
+|         correlation         |                                                                           |        Correlation2D        |   pyxem   |
+|             dpc             |                                                                           |         DPCSignal1D         |   pyxem   |
+|             dpc             |                                                                           |         DPCSignal2D         |   pyxem   |
+|      DielectricFunction     |                            dielectric function                            |      DielectricFunction     |   exspy   |
+|         diffraction         |                                                                           |        Diffraction1D        |   pyxem   |
+|         diffraction         |                                                                           |        Diffraction2D        |   pyxem   |
+|     diffraction_variance    |                                                                           |    DiffractionVariance1D    |   pyxem   |
+|     diffraction_variance    |                                                                           |    DiffractionVariance2D    |   pyxem   |
+|     diffraction_vectors     |                                                                           |      DiffractionVectors     |   pyxem   |
+|     diffraction_vectors     |                                                                           |     DiffractionVectors1D    |   pyxem   |
+|     diffraction_vectors     |                                                                           |     DiffractionVectors2D    |   pyxem   |
+|         tensor_field        |                                                                           |   DisplacementGradientMap   |   pyxem   |
+|             EBSD            |                      electron_backscatter_diffraction                     |             EBSD            | kikuchipy |
+|      EBSDMasterPattern      |                    ebsd_master_pattern, master_pattern                    |      EBSDMasterPattern      | kikuchipy |
+|       ECPMasterPattern      |                             ecp_master_pattern                            |       ECPMasterPattern      | kikuchipy |
+|           EDS_SEM           |                                                                           |        EDSSEMSpectrum       |   exspy   |
+|           EDS_TEM           |                                                                           |        EDSTEMSpectrum       |   exspy   |
+|             EELS            |                                  TEM EELS                                 |         EELSSpectrum        |   exspy   |
+|              EL             |                      ELSpectrum, electroluminescence                      |          ELSpectrum         |  lumispy  |
+|     electron_diffraction    |                                                                           |    ElectronDiffraction1D    |   pyxem   |
+|     electron_diffraction    |                                                                           |    ElectronDiffraction2D    |   pyxem   |
+|           hologram          |                                                                           |        HologramImage        |  holospy  |
+|      insitu_diffraction     |                                                                           |     InSituDiffraction2D     |   pyxem   |
+| labeled_diffraction_vectors |                                                                           | LabeledDiffractionVectors2D |   pyxem   |
+|         Luminescence        |                            LuminescenceSpectrum                           |         LumiSpectrum        |  lumispy  |
+|          Transient          |            TRLumi, TR luminescence, time-resolved luminescence            |        LumiTransient        |  lumispy  |
+|        TransientSpec        | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |    LumiTransientSpectrum    |  lumispy  |
+|       orientation_map       |                                                                           |        OrientationMap       |   pyxem   |
+|              PL             |                       PLSpectrum, photoluminescence                       |          PLSpectrum         |  lumispy  |
+|  pair_distribution_function |                                                                           |  PairDistributionFunction1D |   pyxem   |
+|      polar_diffraction      |                                                                           |      PolarDiffraction2D     |   pyxem   |
+|        polar_vectors        |                                                                           |         PolarVectors        |   pyxem   |
+|            power            |                                                                           |           Power2D           |   pyxem   |
+|      reduced_intensity      |                                                                           |      ReducedIntensity1D     |   pyxem   |
+|       vector_matching       |                                                                           |    VectorMatchingResults    |   pyxem   |
+|       VirtualBSEImage       |                     virtual_backscatter_electron_image                    |       VirtualBSEImage       | kikuchipy |
+|      virtual_dark_field     |                                                                           |    VirtualDarkFieldImage    |   pyxem   |
 
 

--- a/extension_list.txt
+++ b/extension_list.txt
@@ -1,5 +1,6 @@
 exspy
 holospy
 hyperspy
+kikuchipy
 lumispy
 pyxem

--- a/make_README.py
+++ b/make_README.py
@@ -2,7 +2,7 @@ import contextlib
 import io
 import os
 
-from prettytable import MARKDOWN
+from prettytable import TableStyle
 import hyperspy.api as hs
 
 
@@ -11,7 +11,7 @@ readme_source_folder = 'readme_source'
 # Get the information from hyperspy
 f = io.StringIO()
 with contextlib.redirect_stdout(f):
-    hs.print_known_signal_types(style=MARKDOWN)
+    hs.print_known_signal_types(style=TableStyle.MARKDOWN)
 table_ascii = f.getvalue()
 
 with open(os.path.join(readme_source_folder, '2-extension_table.md'), "w") as f:

--- a/readme_source/1-readme_base.md
+++ b/readme_source/1-readme_base.md
@@ -21,7 +21,7 @@ and send us a pull request.
 | [holospy](https://github.com/hyperspy/holospy)                                 | Electron holography                                                                    |
 | [hyperspy-gui-ipywidgets](https://github.com/hyperspy/hyperspy_gui_ipywidgets) | ipywidgets widgets for HyperSpy                                                        |
 | [hyperspy-gui-traitsui](https://github.com/hyperspy/hyperspy_gui_traitsui)     | traitsui widgets for HyperSpy                                                          |
-| [kikuchipy](https://github.com/kikuchipy/kikuchipy)                            | Processing, simulating and indexing of electron backscatter diffraction patterns       |
+| [kikuchipy](https://github.com/pyxem/kikuchipy)                                | Processing, simulating and indexing of electron backscatter diffraction patterns       |
 | [LumiSpy](https://github.com/lumispy/lumispy)                                  | Analysis of luminescence spectroscopy data                                             |
 | [pyxem](https://github.com/pyxem/pyxem)                                        | Multi-dimensional diffraction microscopy                                               |
 | [rosettasciio](https://github.com/hyperspy/rosettasciio)                       | Reading and writing of scientific data formats.                                        |

--- a/readme_source/2-extension_table.md
+++ b/readme_source/2-extension_table.md
@@ -1,40 +1,44 @@
-|         signal_type         |                                  aliases                                  |          class name         | package |
-| :-------------------------: | :-----------------------------------------------------------------------: | :-------------------------: | :-----: |
-|          beam_shift         |                                                                           |          BeamShift          |  pyxem  |
-|            CL_SEM           |                       CLSEM, cathodoluminescence SEM                      |        CLSEMSpectrum        | lumispy |
-|           CL_STEM           |                      CLSTEM, cathodoluminescence STEM                     |        CLSTEMSpectrum       | lumispy |
-|              CL             |                      CLSpectrum, cathodoluminescence                      |          CLSpectrum         | lumispy |
-|         correlation         |                                                                           |        Correlation1D        |  pyxem  |
-|         correlation         |                                                                           |        Correlation2D        |  pyxem  |
-|             dpc             |                                                                           |         DPCSignal1D         |  pyxem  |
-|             dpc             |                                                                           |         DPCSignal2D         |  pyxem  |
-|      DielectricFunction     |                            dielectric function                            |      DielectricFunction     |  exspy  |
-|         diffraction         |                                                                           |        Diffraction1D        |  pyxem  |
-|         diffraction         |                                                                           |        Diffraction2D        |  pyxem  |
-|     diffraction_variance    |                                                                           |    DiffractionVariance1D    |  pyxem  |
-|     diffraction_variance    |                                                                           |    DiffractionVariance2D    |  pyxem  |
-|     diffraction_vectors     |                                                                           |      DiffractionVectors     |  pyxem  |
-|     diffraction_vectors     |                                                                           |     DiffractionVectors1D    |  pyxem  |
-|     diffraction_vectors     |                                                                           |     DiffractionVectors2D    |  pyxem  |
-|         tensor_field        |                                                                           |   DisplacementGradientMap   |  pyxem  |
-|           EDS_SEM           |                                                                           |        EDSSEMSpectrum       |  exspy  |
-|           EDS_TEM           |                                                                           |        EDSTEMSpectrum       |  exspy  |
-|             EELS            |                                  TEM EELS                                 |         EELSSpectrum        |  exspy  |
-|              EL             |                      ELSpectrum, electroluminescence                      |          ELSpectrum         | lumispy |
-|     electron_diffraction    |                                                                           |    ElectronDiffraction1D    |  pyxem  |
-|     electron_diffraction    |                                                                           |    ElectronDiffraction2D    |  pyxem  |
-|           hologram          |                                                                           |        HologramImage        | holospy |
-|      insitu_diffraction     |                                                                           |     InSituDiffraction2D     |  pyxem  |
-| labeled_diffraction_vectors |                                                                           | LabeledDiffractionVectors2D |  pyxem  |
-|         Luminescence        |                            LuminescenceSpectrum                           |         LumiSpectrum        | lumispy |
-|          Transient          |            TRLumi, TR luminescence, time-resolved luminescence            |        LumiTransient        | lumispy |
-|        TransientSpec        | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |    LumiTransientSpectrum    | lumispy |
-|       orientation_map       |                                                                           |        OrientationMap       |  pyxem  |
-|              PL             |                       PLSpectrum, photoluminescence                       |          PLSpectrum         | lumispy |
-|  pair_distribution_function |                                                                           |  PairDistributionFunction1D |  pyxem  |
-|      polar_diffraction      |                                                                           |      PolarDiffraction2D     |  pyxem  |
-|        polar_vectors        |                                                                           |         PolarVectors        |  pyxem  |
-|            power            |                                                                           |           Power2D           |  pyxem  |
-|      reduced_intensity      |                                                                           |      ReducedIntensity1D     |  pyxem  |
-|       vector_matching       |                                                                           |    VectorMatchingResults    |  pyxem  |
-|      virtual_dark_field     |                                                                           |    VirtualDarkFieldImage    |  pyxem  |
+|         signal_type         |                                  aliases                                  |          class name         |  package  |
+| :-------------------------: | :-----------------------------------------------------------------------: | :-------------------------: | :-------: |
+|          beam_shift         |                                                                           |          BeamShift          |   pyxem   |
+|            CL_SEM           |                       CLSEM, cathodoluminescence SEM                      |        CLSEMSpectrum        |  lumispy  |
+|           CL_STEM           |                      CLSTEM, cathodoluminescence STEM                     |        CLSTEMSpectrum       |  lumispy  |
+|              CL             |                      CLSpectrum, cathodoluminescence                      |          CLSpectrum         |  lumispy  |
+|         correlation         |                                                                           |        Correlation1D        |   pyxem   |
+|         correlation         |                                                                           |        Correlation2D        |   pyxem   |
+|             dpc             |                                                                           |         DPCSignal1D         |   pyxem   |
+|             dpc             |                                                                           |         DPCSignal2D         |   pyxem   |
+|      DielectricFunction     |                            dielectric function                            |      DielectricFunction     |   exspy   |
+|         diffraction         |                                                                           |        Diffraction1D        |   pyxem   |
+|         diffraction         |                                                                           |        Diffraction2D        |   pyxem   |
+|     diffraction_variance    |                                                                           |    DiffractionVariance1D    |   pyxem   |
+|     diffraction_variance    |                                                                           |    DiffractionVariance2D    |   pyxem   |
+|     diffraction_vectors     |                                                                           |      DiffractionVectors     |   pyxem   |
+|     diffraction_vectors     |                                                                           |     DiffractionVectors1D    |   pyxem   |
+|     diffraction_vectors     |                                                                           |     DiffractionVectors2D    |   pyxem   |
+|         tensor_field        |                                                                           |   DisplacementGradientMap   |   pyxem   |
+|             EBSD            |                      electron_backscatter_diffraction                     |             EBSD            | kikuchipy |
+|      EBSDMasterPattern      |                    ebsd_master_pattern, master_pattern                    |      EBSDMasterPattern      | kikuchipy |
+|       ECPMasterPattern      |                             ecp_master_pattern                            |       ECPMasterPattern      | kikuchipy |
+|           EDS_SEM           |                                                                           |        EDSSEMSpectrum       |   exspy   |
+|           EDS_TEM           |                                                                           |        EDSTEMSpectrum       |   exspy   |
+|             EELS            |                                  TEM EELS                                 |         EELSSpectrum        |   exspy   |
+|              EL             |                      ELSpectrum, electroluminescence                      |          ELSpectrum         |  lumispy  |
+|     electron_diffraction    |                                                                           |    ElectronDiffraction1D    |   pyxem   |
+|     electron_diffraction    |                                                                           |    ElectronDiffraction2D    |   pyxem   |
+|           hologram          |                                                                           |        HologramImage        |  holospy  |
+|      insitu_diffraction     |                                                                           |     InSituDiffraction2D     |   pyxem   |
+| labeled_diffraction_vectors |                                                                           | LabeledDiffractionVectors2D |   pyxem   |
+|         Luminescence        |                            LuminescenceSpectrum                           |         LumiSpectrum        |  lumispy  |
+|          Transient          |            TRLumi, TR luminescence, time-resolved luminescence            |        LumiTransient        |  lumispy  |
+|        TransientSpec        | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |    LumiTransientSpectrum    |  lumispy  |
+|       orientation_map       |                                                                           |        OrientationMap       |   pyxem   |
+|              PL             |                       PLSpectrum, photoluminescence                       |          PLSpectrum         |  lumispy  |
+|  pair_distribution_function |                                                                           |  PairDistributionFunction1D |   pyxem   |
+|      polar_diffraction      |                                                                           |      PolarDiffraction2D     |   pyxem   |
+|        polar_vectors        |                                                                           |         PolarVectors        |   pyxem   |
+|            power            |                                                                           |           Power2D           |   pyxem   |
+|      reduced_intensity      |                                                                           |      ReducedIntensity1D     |   pyxem   |
+|       vector_matching       |                                                                           |    VectorMatchingResults    |   pyxem   |
+|       VirtualBSEImage       |                     virtual_backscatter_electron_image                    |       VirtualBSEImage       | kikuchipy |
+|      virtual_dark_field     |                                                                           |    VirtualDarkFieldImage    |   pyxem   |


### PR DESCRIPTION
We've just released kikuchipy v0.11.0 on PyPI, compatible with HyperSpy >= 2.2 (https://pypi.org/project/kikuchipy/).

I've therefore re-enabled kikuchipy here.